### PR TITLE
Cancel capture with Esc and a couple other small fixes

### DIFF
--- a/PoE-HarvestVendor.ahk
+++ b/PoE-HarvestVendor.ahk
@@ -1640,8 +1640,8 @@ Options: (White space separated)
         KeyWait, LButton, D T0.1  ; 100ms timeout
         isLButtonDown := (ErrorLevel == 0)
     }
-    Hotkey, Escape, SelectAreaEscape, Off
 
+    areaRect := []
     if (!SelectAreaEscapePressed)
     {
         CoordMode, Mouse, Screen
@@ -1670,7 +1670,8 @@ Options: (White space separated)
         WinSet, Transparent, %t%
         Gui %g%: Color, %c%
         ;Hotkey := RegExReplace(A_ThisHotkey,"^(\w* & |\W*)")
-        While, (GetKeyState("LButton"))
+
+        While (GetKeyState("LButton") AND !SelectAreaEscapePressed)
         {
             Sleep, 10
             MouseGetPos, MXend, MYend        
@@ -1679,36 +1680,38 @@ Options: (White space separated)
             Y := (MY < MYend) ? MY : MYend
             Gui %g%: Show, x%X% y%Y% w%w% h%h% NA
         }
-        Gui %g%: Destroy
-        Gui, Select:Destroy
-        Gui, HarvestUI:Default
 
-        if m = s ; Screen
+        Gui %g%: Destroy
+
+        if (!SelectAreaEscapePressed)
         {
-            MouseGetPos, MXend, MYend
-            If ( MX > MXend )
-                temp := MX, MX := MXend, MXend := temp ;* scale
-            If ( MY > MYend )
-                temp := MY, MY := MYend, MYend := temp ;* scale
-            Return [MX,MXend,MY,MYend]
-        }
-        else ; Relative
-        {
-            CoordMode, Mouse, Relative
-            MouseGetPos, rMXend, rMYend
-            If ( rMX > rMXend )
-                temp := rMX, rMX := rMXend, rMXend := temp
-            If ( rMY > rMYend )
-                temp := rMY, rMY := rMYend, rMYend := temp
-            Return [rMX,rMXend,rMY,rMYend]
+            if m = s ; Screen
+            {
+                MouseGetPos, MXend, MYend
+                If ( MX > MXend )
+                    temp := MX, MX := MXend, MXend := temp ;* scale
+                If ( MY > MYend )
+                    temp := MY, MY := MYend, MYend := temp ;* scale
+                areaRect := [MX,MXend,MY,MYend]
+            }
+            else ; Relative
+            {
+                CoordMode, Mouse, Relative
+                MouseGetPos, rMXend, rMYend
+                If ( rMX > rMXend )
+                    temp := rMX, rMX := rMXend, rMXend := temp
+                If ( rMY > rMYend )
+                    temp := rMY, rMY := rMYend, rMYend := temp
+                areaRect := [rMX,rMXend,rMY,rMYend]
+            }
         }
     }
-    else
-    {
-        Gui, Select:Destroy
-        Gui, HarvestUI:Default
-        Return []
-    }
+
+    Hotkey, Escape, SelectAreaEscape, Off
+
+    Gui, Select:Destroy
+    Gui, HarvestUI:Default
+    return areaRect
 }
 
 ;this is for tooltips to work, got it from examples from an AHK webinar

--- a/PoE-HarvestVendor.ahk
+++ b/PoE-HarvestVendor.ahk
@@ -268,8 +268,8 @@ gui, font, s10
 	gui, font
 	Gui, Help:Show, w400 h610, Help
 return
-	HelpExit:
-	HelpClose:	
+HelpGuiClose:
+	Gui, Help:Destroy
 	Gui, HarvestUI:Default
 return
 
@@ -316,8 +316,7 @@ settings:
 	gui, Settings:Show, w410 h330
 	
 return
-SettingsExit:
-SettingsClose:		
+SettingsGuiClose:
 	hotkey, %GuiKey%, on
 	hotkey, %ScanKey%, on
 	Gui, Settings:Destroy

--- a/PoE-HarvestVendor.ahk
+++ b/PoE-HarvestVendor.ahk
@@ -21,6 +21,8 @@ global y_end := 0
 global rescan
 global seenInstructions
 
+global PID := DllCall("Kernel32\GetCurrentProcessId")
+
 ; == init settings ==
 
 iniRead, seenInstructions,  %A_WorkingDir%/settings.ini, Other, seenInstructions
@@ -583,7 +585,7 @@ processCrafts(file) {
 	RunWait, %command%
     
     sleep, 1000 ;sleep cos if i show the Gui too quick the capture will grab screenshot of gui   	
-	WinActivate, ahk_exe AutoHotkey.exe
+	WinActivate, ahk_pid %PID%
 	Tooltip
 
 	if !FileExist(file) {


### PR DESCRIPTION
Just started using this neat tool and the fact that you can't easily cancel the capture bugged me to no end, so here it is.

Commit a86bfa8 fixes an issue I was having when closing the settings window without saving, which would result in the hotkeys not working anymore.